### PR TITLE
chore: use sustainable-npm in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/setup-node@v4.2.0
         with:
           node-version: 20
-      - uses: lowlydba/sustainable-npm@v1
-      - run: npm ci --no-audit --no-fund --loglevel=error
+      - uses: lowlydba/sustainable-npm@v1.0.0
+      - run: npm ci
       - run: npm run lint
       - run: npm test
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/setup-node@v4.2.0
         with:
           node-version: 20
-      - uses: lowlydba/sustainable-npm@v1.0.0
+      - uses: lowlydba/sustainable-npm@v1.1.0
       - run: npm ci
       - run: npm run lint
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v4.2.0
         with:
           node-version: 20
+      - uses: lowlydba/sustainable-npm@v1
       - run: npm ci --no-audit --no-fund --loglevel=error
       - run: npm run lint
       - run: npm test


### PR DESCRIPTION
Use sustainable-npm action to reduce unnecessary compute when doing npm installs.